### PR TITLE
Fix various regressions

### DIFF
--- a/helpers/aws-ec2.js
+++ b/helpers/aws-ec2.js
@@ -141,7 +141,7 @@ async function createSnapshot(id, volMeta) {
         },
       ],
     };
-    const command = new CreateSnapshotCommand(parms);
+    const command = new ec2.CreateSnapshotCommand(parms);
     await client.send(command);
   } catch (err) {
     throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ebs-fushu",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ebs-fushu",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.300.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ebs-fushu",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
Note that Amazon changed from `err.code` to `err.Code` in their Error objects.